### PR TITLE
Add package sources

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -7,4 +7,7 @@ packages:
   - shinydashboard
   - shinyWidgets
   - shinyBS
-  - tidyverse 
+  - tidyverse
+package_sources:
+  github:
+  - mrc-ide/drpower


### PR DESCRIPTION
Hi @shaziaruybal, here's a small tweak to your provisioning script that installs DRpower properly.

I've deployed the app (with this fix) at http://shiny.dide.ic.ac.uk/DRpower-app - have a play and let me know if you want it redeployed following any changes at your end.

In the meantime, please do merge this PR so that it will be included in any future updates, and let me know so I can update the configuration on the server